### PR TITLE
substitute all instances in a string

### DIFF
--- a/lib/motion-i18n/i18n.rb
+++ b/lib/motion-i18n/i18n.rb
@@ -3,7 +3,7 @@ module I18n
     def translate(key, substitutions = {})
       String.new((NSBundle.mainBundle.localizedStringForKey(key, value:"", table:nil))).tap do |result|
         substitutions.each do |key, value|
-          result.sub!("%{#{key}}", value.to_s)
+          result.gsub!("%{#{key}}", value.to_s)
         end
       end
     end

--- a/resources/en.lproj/Localizable.strings
+++ b/resources/en.lproj/Localizable.strings
@@ -1,2 +1,3 @@
 "test.string" = "Test string";
 "test.substitutions" = "%{count} substitutions";
+"test.multiple_substitutions" = "%{count} substitutions %{count}";

--- a/spec/motion-i18n/i18n_spec.rb
+++ b/spec/motion-i18n/i18n_spec.rb
@@ -11,6 +11,10 @@ describe "I18n" do
     it "should plug in substitutions" do
       I18n.translate("test.substitutions", :count => 5).should == "5 substitutions"
     end
+
+    it "substitutes multiple instances" do
+      I18n.translate("test.multiple_substitutions", :count => 5).should == "5 substitutions 5"
+    end
     
     it "should have shortcut" do
       I18n.t("test.string").should == I18n.translate("test.string")


### PR DESCRIPTION
Thanks for a great library!

We encountered a translation that unfortunately required the same substitution to happen multiple times. It was a quick tweak that others might find useful.

Thanks again.
