### PR TITLE
fix droid_convert

### DIFF
--- a/lib/tasks/translate.rb
+++ b/lib/tasks/translate.rb
@@ -14,9 +14,9 @@ def droid_convert(file, namespace, value)
       droid_convert(file, "#{namespace}.#{key}", value)
     end
   else
-    encoded_val = value.to_s.gsub("'", "&apos;").gsub('"', "&quot;") #.encode(:xml => :text)
+    encoded_val = value.to_s.gsub("'", "&apos;").gsub('"', "&quot;").encode(:xml => :text)
     encoded_name = namespace.to_s.gsub(" ", "_")
-    file.puts %{<string name="#{encoded_name}">#{encoded_val}</string>}
+    file.puts %{<string name="#{encoded_name}">} + encoded_val + '</string>' # dont interpolate the actual value.
   end
 end
 

--- a/lib/tasks/translate.rb
+++ b/lib/tasks/translate.rb
@@ -16,7 +16,7 @@ def droid_convert(file, namespace, value)
   else
     encoded_val = value.to_s.gsub("'", "&apos;").gsub('"', "&quot;").encode(:xml => :text)
     encoded_name = namespace.to_s.gsub(" ", "_")
-    file.puts %{<string name="#{encoded_name}">} + encoded_val + '</string>' # dont interpolate the actual value.
+    file.puts %{<string name="#{encoded_name}">#{encoded_val}</string>}
   end
 end
 

--- a/lib/tasks/translate.rb
+++ b/lib/tasks/translate.rb
@@ -11,11 +11,10 @@ end
 def droid_convert(file, namespace, value)
   if value.is_a?(Hash)
     value.each do |key, value|
-      convert(file, "#{namespace}.#{key}", value)
+      droid_convert(file, "#{namespace}.#{key}", value)
     end
   else
-    # file.puts %{"#{namespace}" = "#{value.to_s}";}
-    encoded_val = value.to_s.gsub("'", "&apos;").gsub('"', "&quot;").encode(:xml => :text)
+    encoded_val = value.to_s.gsub("'", "&apos;").gsub('"', "&quot;") #.encode(:xml => :text)
     encoded_name = namespace.to_s.gsub(" ", "_")
     file.puts %{<string name="#{encoded_name}">#{encoded_val}</string>}
   end

--- a/motion-i18n.gemspec
+++ b/motion-i18n.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "motion-i18n"
-  s.version     = "0.0.3"
+  s.version     = "0.0.4"
   s.authors     = ["Thomas Kadauke"]
   s.email       = ["thomas.kadauke@googlemail.com"]
   s.homepage    = "https://github.com/tkadauke/motion-i18n"


### PR DESCRIPTION
hey, I was fooling around with doing newlines on Android...

apparently you can't do it unless the string is a single-quoted string in the <locale>.yml files

anyway, while I was digging I saw the droid_convert function may fail if given a hash, it will go to the iOS code. this will fix that

thanks

let me know what you think